### PR TITLE
Add components needed to onboard this hub to AWS

### DIFF
--- a/hub-config/admin.json
+++ b/hub-config/admin.json
@@ -1,13 +1,21 @@
 {
-    "schema_version": "https://raw.githubusercontent.com/Infectious-Disease-Modeling-Hubs/schemas/main/v2.0.0/admin-schema.json",
+    "schema_version": "https://raw.githubusercontent.com/Infectious-Disease-Modeling-Hubs/schemas/main/v2.0.1/admin-schema.json",
     "name": "FluSight 1 Forecast Hub",
     "maintainer": "Consortium of Infectious Disease Modeling Hubs",
     "contact": {
         "name": "Luke Mullany",
         "email": "Luke.Mullany@jhuapl.edu"
     },
-    "repository_url": "https://github.com/lmullany/flusight1_hub",
+    "repository_url": "https://github.com/Infectious-Disease-Modeling-Hubs/flusight1_hub",
     "file_format": ["csv", "parquet"],
     "timezone": "US/Eastern",
-    "model_output_dir": "model-output"
+    "model_output_dir": "model-output",
+    "cloud": {
+        "enabled": true,
+        "host": {
+          "name": "aws",
+          "storage_service": "s3",
+          "storage_location": "temp-flusight-archive-hub"
+        }
+    }
 }

--- a/hub-config/tasks.json
+++ b/hub-config/tasks.json
@@ -1,5 +1,5 @@
 {
-    "schema_version": "https://raw.githubusercontent.com/Infectious-Disease-Modeling-Hubs/schemas/main/v2.0.0/tasks-schema.json",
+    "schema_version": "https://raw.githubusercontent.com/Infectious-Disease-Modeling-Hubs/schemas/main/v2.0.1/tasks-schema.json",
     "rounds": [{
             "round_id_from_variable": true,
             "round_id": "origin_date",


### PR DESCRIPTION
This changeset adds the two things required for AWS onboarding: a schema upgrade + corresponding cloud information and the GitHub workflow that will sync the hub's data to S3.